### PR TITLE
Keep preCondition and condition original behaviour

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -154,7 +154,7 @@ export abstract class AutoMapperBase {
       );
 
       if (preCondition && !preCondition.predicate(sourceObj)) {
-        set(destinationObj, destinationMemberPath, preCondition.defaultValue);
+        set(destinationObj, destinationMemberPath, preCondition.defaultValue || null);
         continue;
       }
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -276,7 +276,7 @@ export abstract class AutoMapperBase {
         return;
       }
 
-      set(destinationObj, destinationMemberPath, condition.defaultValue);
+      set(destinationObj, destinationMemberPath, condition.defaultValue || null);
       return;
     }
 


### PR DESCRIPTION
Additional modification for the issue #54 

@nartc have added feature to set default value for `preCondition` and `condition` but seems the mapping will be `undefined` if users not providing the default value.

This PR is to keep the original behaviour that if users not providing the default value, `null` will be mapped to the object property instead of `undefined`