### PR TITLE
fix(index.ts): export naming conventions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './automapper';
+export * from './conventions';
 export * from './create-map-metadata';
 export * from './types';
 export * from './decorators';


### PR DESCRIPTION
Fix #165 by exporting all naming conventions.