### PR TITLE
Mutate nested patch

### DIFF
--- a/packages/core/src/lib/map/map.ts
+++ b/packages/core/src/lib/map/map.ts
@@ -136,11 +136,7 @@ export function mapReturn<
     options,
     mapper,
     errorHandler,
-    setMemberFn:
-      (destinationMemberPath: string[], destination: TDestination) =>
-        (value: unknown) => {
-          destination = set(destination, destinationMemberPath, value);
-        },
+    setMemberFn: setMemberReturnFn,
     isMapArray,
   });
 }
@@ -363,9 +359,7 @@ Original error: ${originalError}`;
             options: { extraArguments },
             mapper,
             errorHandler,
-            setMemberFn: (memberPath, nestedDestination) => (value) => {
-              nestedDestination = set(nestedDestination, memberPath, value);
-            },
+            setMemberFn: setMemberReturnFn,
           }),
         );
         continue;
@@ -469,4 +463,13 @@ function setMemberMutateFn(destinationObj: Record<string, unknown>) {
 
 function getMemberMutateFn(destinationObj: Record<string, unknown>) {
   return (memberPath: string[] | undefined) => get(destinationObj, memberPath) as Record<string, unknown>;
+}
+
+function setMemberReturnFn<TDestination extends Dictionary<TDestination> = any>(
+  destinationMemberPath: string[],
+  destination: TDestination
+) {
+  return (value: unknown) => {
+    destination = set(destination, destinationMemberPath, value);
+  };
 }

--- a/packages/core/src/lib/map/map.ts
+++ b/packages/core/src/lib/map/map.ts
@@ -171,15 +171,8 @@ export function mapMutate<
     options,
     mapper,
     errorHandler,
-    setMemberFn: (destinationMember: string[]) => (value: unknown) => {
-      if (value === undefined) {
-        return;
-      }
-      setMutate(destinationObj, destinationMember, value);
-    },
-    getMemberFn: (memberPath: string[] | undefined) => {
-      return get(destinationObj, memberPath) as Record<string, unknown>;
-    }
+    setMemberFn: setMemberMutateFn(destinationObj),
+    getMemberFn: getMemberMutateFn(destinationObj)
   });
 }
 
@@ -356,14 +349,8 @@ Original error: ${originalError}`;
             options: { extraArguments },
             mapper,
             errorHandler,
-            setMemberFn: (memberPath) => (value) => {
-              if (value !== undefined) {
-                setMutate(destinationMemberValue, memberPath, value);
-              }
-            },
-            getMemberFn: (memberPath) => {
-              return get(destinationMemberValue, memberPath) as Record<string, unknown>;
-            }
+            setMemberFn: setMemberMutateFn(destinationMemberValue),
+            getMemberFn: getMemberMutateFn(destinationMemberValue)
           });
           continue;
         }
@@ -470,4 +457,16 @@ export function mapArray<
   }
 
   return destinationArray;
+}
+
+function setMemberMutateFn(destinationObj: Record<string, unknown>) {
+  return (destinationMember: string[]) => (value) => {
+    if (value !== undefined) {
+      setMutate(destinationObj, destinationMember, value);
+    }
+  };
+}
+
+function getMemberMutateFn(destinationObj: Record<string, unknown>) {
+  return (memberPath: string[] | undefined) => get(destinationObj, memberPath) as Record<string, unknown>;
 }

--- a/packages/integration-test/src/lib/with-classes/fixtures/profiles/avatar.profile.ts
+++ b/packages/integration-test/src/lib/with-classes/fixtures/profiles/avatar.profile.ts
@@ -29,6 +29,10 @@ export const avatarProfile: MappingProfile = (mapper) => {
     .forMember((d) => d.shouldBeSubstituted, nullSubstitution('sub'));
 
   mapper
+    .createMap(AvatarVm, Avatar)
+    .forMember((d) => d.shouldIgnore, ignore());
+
+  mapper
     .createMap(Avatar, PascalAvatarVm)
     .forMember(
       (d) => d.Url,

--- a/packages/integration-test/src/lib/with-classes/fixtures/profiles/user-profile.profile.ts
+++ b/packages/integration-test/src/lib/with-classes/fixtures/profiles/user-profile.profile.ts
@@ -1,4 +1,4 @@
-import { convertUsing, mapWith } from '@automapper/core';
+import { convertUsing, mapWith, mapFrom } from '@automapper/core';
 import type { MappingProfile } from '@automapper/types';
 import { dateToStringConverter } from '../converters/date-to-string.converter';
 import { Avatar, AvatarVm } from '../models/avatar';
@@ -28,6 +28,13 @@ export const userProfileProfile: MappingProfile = (mapper) => {
     .forMember(
       (d) => d.birthday,
       convertUsing(dateToStringConverter, (s) => s.birthday)
+    );
+
+  mapper
+    .createMap(UserProfileVm, UserProfile)
+    .forMember(
+      (d) => d.birthday,
+      mapFrom(s => s.birthday && new Date(s.birthday)),
     );
 
   mapper

--- a/packages/integration-test/src/lib/with-classes/map-mutate.spec.ts
+++ b/packages/integration-test/src/lib/with-classes/map-mutate.spec.ts
@@ -21,6 +21,8 @@ import {
   userProfile,
 } from './fixtures/profiles/user.profile';
 import { getPascalUser, getUser } from './utils/get-user';
+import { UserProfileVm } from './fixtures/models/user-profile';
+import { AvatarVm } from './fixtures/models/avatar';
 
 describe('Map Mutate', () => {
   const [mapper] = setupClasses('mapMutate');
@@ -105,6 +107,34 @@ describe('Map Mutate', () => {
     expect(user.lastName).toEqual(vm.last);
     expect(user.profile).toEqual(originalUser.profile);
     expect(user.job).toEqual(originalUser.job);
+  });
+
+  it('should not map undefined properly of nested field', () => {
+    mapper
+      .addProfile(addressProfile)
+      .addProfile(avatarProfile)
+      .addProfile(userProfileProfile)
+      .addProfile(userProfile);
+
+    const originalUser = getUser();
+    const user = { ...getUser() };
+
+    const vm = new UserVm();
+    vm.profile = {
+      bio: 'Outgoing-ish',
+      avatar: { url: 'uniform-resource-locator.com' } as AvatarVm,
+    } as UserProfileVm;
+
+    mapper.map(vm, User, UserVm, user);
+    expect(user.profile.bio).toEqual(vm.profile.bio);
+    expect(user.profile.avatar.url).toEqual(vm.profile.avatar.url);
+
+    expect(user.profile.birthday).toEqual(originalUser.profile.birthday);
+    expect(user.profile.avatar.source).toEqual(originalUser.profile.avatar.source);
+    expect(user.profile.avatar.shouldIgnore).toEqual(originalUser.profile.avatar.shouldIgnore);
+    expect(user.profile.avatar.shouldBeSubstituted).toEqual(originalUser.profile.avatar.shouldBeSubstituted);
+    expect(user.profile.avatar.forCondition).toEqual(originalUser.profile.avatar.forCondition);
+    expect(user.profile.addresses).toEqual(originalUser.profile.addresses);
   });
 
   it('should map correctly with condition, preCondition, and nullSubstitution', () => {


### PR DESCRIPTION
- Refactor `map()` function parameter to one object parameter, to let both `isMapArray` and newly added `getMemberFn` tobe optional without parameter order.
- Use `getMemberFn` to check whether destination member already exist and `setMutate` to that object if not undefined.

close #316