### PR TITLE
Open up sequelize peer dependency to more of version 6

### DIFF
--- a/packages/sequelize/package.json
+++ b/packages/sequelize/package.json
@@ -3,7 +3,7 @@
   "version": "6.1.1",
   "peerDependencies": {
     "reflect-metadata": "~0.1.13",
-    "sequelize": "~6.5.0"
+    "sequelize": "^6.5.0"
   },
   "sideEffects": false,
   "engines": {


### PR DESCRIPTION
The current setup only allows sequelize versions `6.5.0` and `6.5.1` to be installed without a peer dependency error.

With this proposal, NPM will not surface the peer dependency error if any of these versions of sequelize are installed `6.5.0`, `6.5.1`, `6.6.0`, `6.6.1`, `6.6.2`, `6.6.4`, `6.6.5`, and any upcoming version that matches `6.x.x`.