### PR TITLE
ci: avoid running unit test workflow when no changes are made on code

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,10 +3,25 @@
 
 name: Unit Test
 on:
+  # Allow triggering this workflow manually via GitHub CLI/web
+  workflow_dispatch:
+
   push:
     branches: [ main ]
+    paths:
+      - '**.ts'
+      - '**.js'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'yarn.lock'
   pull_request:
     branches: [ main ]
+    paths:
+      - '**.ts'
+      - '**.js'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'yarn.lock'
 
 jobs:
   jest:


### PR DESCRIPTION
If the PR doesn't introduces any change to some `.js`/`.ts`/manifest file, then **Unit Test** workflow can be skipped, right?

More about the `paths` parameter here:
https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onpushpull_requestpaths