### PR TITLE
docs: display last updated date and author

### DIFF
--- a/docs-site/docusaurus.config.js
+++ b/docs-site/docusaurus.config.js
@@ -107,9 +107,11 @@ module.exports = {
       '@docusaurus/preset-classic',
       {
         docs: {
-          sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           editUrl: 'https://github.com/nartc/mapper/tree/main/docs-site',
+          sidebarPath: require.resolve('./sidebars.js'),
+          showLastUpdateAuthor: true,
+          showLastUpdateTime: true,
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Now we'll get something like this:

![image](https://user-images.githubusercontent.com/13461315/147515798-3da3efb8-0323-4e89-834f-6b7402330ddc.png)

I didn't tested this locally, I've just followed this: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs