### PR TITLE
fix(classes): Distinguishing Date from Date[] types in classes plugin instantiation of source to-map objects

### DIFF
--- a/packages/classes/src/lib/utils/instantiate.util.ts
+++ b/packages/classes/src/lib/utils/instantiate.util.ts
@@ -67,7 +67,7 @@ export function instantiate<TModel extends Dictionary<TModel>>(
     }
 
     // if is Date, assign a new Date value if valueAtKey is defined, otherwise, undefined
-    if (isDateConstructor(metaResult)) {
+    if (isDateConstructor(metaResult) && !Array.isArray(valueAtKey)) {
       const value = isDefined(valueAtKey)
         ? new Date(valueAtKey as number)
         : undefined;


### PR DESCRIPTION
Seems like when instantiating source objects for mapping in classes plugin, Date type is inferred by looking at metadata information the source class only. This causes Date[] to be treated as Date types, resulting in invalid mapping results.

Adding array check for this case. 

Related to issue #397 