### PR TITLE
feat(classes): use class constructor's name instead of constructor function

### DIFF
--- a/packages/classes/src/lib/automap.ts
+++ b/packages/classes/src/lib/automap.ts
@@ -52,8 +52,8 @@ export function AutoMap(
         // if typeFn is still null/undefined, fail fast;
         if (options.type == null) {
             console.warn(`
-Cannot determine type metadata of "${String(propertyKey)}" on ${
-                target.constructor
+Cannot determine type metadata of "${String(propertyKey)}" on class ${
+                target.constructor.name
             }.
 "${String(propertyKey)}" metadata has been skipped.
 Manually provide the "type" metadata to prevent unexpected behavior.


### PR DESCRIPTION
closes #451

Now we'll get this message instead:

![image](https://user-images.githubusercontent.com/13461315/162263432-d53eb300-897f-4f1a-8787-ee1eb0f80c65.png)
