### PR TITLE
Use readonly access modifier in MappingStrategy interface instead of …

### DIFF
--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -559,7 +559,7 @@ export type MetadataList = Array<
 export interface MappingStrategy<TIdentifier extends MetadataIdentifier> {
     destinationConstructor: DestinationConstructor;
     mapper: Mapper;
-    get applyMetadata(): ApplyMetadataFn;
+    readonly applyMetadata: ApplyMetadataFn;
     retrieveMetadata(
         ...identifiers: TIdentifier[]
     ): Map<TIdentifier, MetadataList>;


### PR DESCRIPTION
Using get keyword in ambient types may cause typescript errors in some build environments. Encountered the attached error when running a build using vue-cli in production mode. Tested locally and my changes in the pull request satisfies the TS compiler. PR need ASAP due to release train.
![Screen Shot 2022-06-02 at 11 11 22 AM](https://user-images.githubusercontent.com/3401828/171661906-c25d10d1-9a03-4415-9b32-d720173259ec.png)
 