### PR TITLE
Fix TypeError: Cannot read properties of undefined (reading 'id') bug

### DIFF
--- a/packages/mikro/src/lib/serialize-entity.ts
+++ b/packages/mikro/src/lib/serialize-entity.ts
@@ -13,7 +13,7 @@ const excluded = [
 
 export function serializeEntity(
     item: AnyEntity,
-    itemMetadata: Record<string, unknown>,
+    itemMetadata: Record<string, unknown> | undefined,
     toPojo = false
 ) {
     if (!Utils.isEntity(item)) return item;
@@ -26,7 +26,7 @@ export function serializeEntity(
         }
 
         const value = item[key];
-        const keyMetadata = itemMetadata[key] as Record<string, unknown>;
+        const keyMetadata = itemMetadata && itemMetadata[key] as Record<string, unknown>;
 
         if (Utils.isCollection(value)) {
             result[key] = (value.getSnapshot() || []).map((snapshot) => {


### PR DESCRIPTION
I have encountered the situation that itemMetadata is undefined. My project crashed with the following exception. However, my tiny fix solves the problem. Unfortunately, I was not able to reproduce the bug outside of my project. However, 
it would be great if you could merge my bug fix.

[Nest] 78135  - 07/13/2022, 6:30:58 PM   ERROR [ExceptionsHandler] Cannot read properties of undefined (reading 'id')
```
TypeError: Cannot read properties of undefined (reading 'id')
    at serializeEntity (/home/alwin/WebStormsProjects/project/node_modules/@automapper/mikro/index.cjs:20:37)
    at serializeEntity (/home/alwin/WebStormsProjects/project/node_modules/@automapper/mikro/index.cjs:39:19)
    at Object.mergedOptions.preMap (/home/alwin/WebStormsProjects/project/node_modules/@automapper/mikro/index.cjs:59:14)
    at Proxy.<anonymous> (/home/alwin/WebStormsProjects/project/node_modules/@automapper/core/index.cjs:690:35)
    at Array.map (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```
