### PR TITLE
fix(mikro): infinite loop when using OneToOne eager loading

### DIFF
--- a/packages/mikro/src/lib/serialize-entity.ts
+++ b/packages/mikro/src/lib/serialize-entity.ts
@@ -14,7 +14,9 @@ const excluded = [
 export function serializeEntity(
     item: AnyEntity,
     itemMetadata: Record<string, unknown> | undefined,
-    toPojo = false
+    toPojo = false,
+    memorized = new Map<AnyEntity, Record<string, unknown>>,
+    skipCheckExisting = false
 ) {
     if (!Utils.isEntity(item)) return item;
     if (toPojo) return wrap(item).toPOJO();
@@ -33,6 +35,8 @@ export function serializeEntity(
                 return serializeEntity(
                     snapshot as AnyEntity,
                     keyMetadata,
+                    true,
+                    memorized,
                     true
                 );
             });
@@ -40,23 +44,37 @@ export function serializeEntity(
         }
 
         if (Reference.isReference(value)) {
+            const isExisting = memorized.has(value);
+
+            if (!skipCheckExisting && isExisting) {
+                result[key] = memorized.get(value);
+                continue;
+            }
+
             if (!value.isInitialized()) {
+                memorized.set(value, wrap(value).toPOJO());
                 result[key] = serializeEntity(
                     wrap(value).toPOJO(),
-                    keyMetadata
+                    keyMetadata,
+                    false,
+                    memorized,
+                    !isExisting
                 );
                 continue;
             }
 
+            memorized.set(value, value.getEntity() as Record<string, unknown>);
             result[key] = serializeEntity(
                 value.getEntity(),
                 keyMetadata,
-                typeof keyMetadata === 'object' && isEmpty(keyMetadata)
+                typeof keyMetadata === 'object' && isEmpty(keyMetadata),
+                memorized,
+                !isExisting
             );
             continue;
         }
 
-        result[key] = serializeEntity(value, keyMetadata);
+        result[key] = serializeEntity(value, keyMetadata, false, memorized, false);
     }
 
     if (result['id'] == null && item['id'] != null) {


### PR DESCRIPTION
I am using Mikro version `6.0.0-dev.75`, I am not sure if version `5` face this issue or not. But I think it faces the same issue.

My usage is I have two models with `OneToOne` association, when eager loading, `mikro-orm` will load the model as `reference`, and then `automapper` will call `serializeEntity` infinitely.

Example:

```ts
@Entity()
export class Post extends Base {
  @AutoMap(() => SeriesPost)
  @OneToOne({
    ref: true,
    mappedBy: 'post',
    orphanRemoval: true,
    entity: () => SeriesPost,
  })
  seriesPost: Ref<SeriesPost>;
```

```ts
@Entity()
export class SeriesPost extends Base {
  @OneToOne({
    ref: true,
    entity: () => Post,
    deleteRule: 'cascade',
    inversedBy: 'seriesPost',
  })
  post: Ref<Post>;
}
```

In controller, I use

```ts
    return this.postRepository.findOneOrFail(
      {
        id,
      },
      {
        populate: [
          'seriesPost',
        ],
      },
    );
```

It will cause infinite loop because `post.seriesPost.post` is a `reference` of `post`.

The main idea of the fix is memorized the `POJO`/`raw entity` of the `mikro-orm`, then when we have a cycle, we will get from memorized instead of calling the `serializeEntity`.

Currently, when I do 

```ts
    return this.postRepository.findOneOrFail(
      {
        id,
      },
      {
        populate: [
          'seriesPost',
          'seriesPost.post',
        ],
      },
    );
```

I cannot get the data of `seriesPost.post`, my project does not need that, but I still not know why it does not get that property. Maybe my config is wrong. I will test it later and will have a fix for this case (if it is a bug)