### PR TITLE
fix(classes): fixed transformer ttypescript / ts-patch support

### DIFF
--- a/packages/classes/transformer-plugin/src/README.md
+++ b/packages/classes/transformer-plugin/src/README.md
@@ -199,9 +199,9 @@ export default {
 };
 ```
 
-### ttypescript
+### ts-patch
 
-ttypescript patches typescript in order to use transformers in tsconfig.json. See [ttypescript's README](https://github.com/cevek/ttypescript) for how to use this with module bundlers such as webpack or Rollup.
+ts-patch patches typescript in order to use transformers in tsconfig.json. See [ts-patch's README](https://github.com/nonara/ts-patch) for how to use this with module bundlers such as webpack or Rollup.
 
 ```
 {
@@ -210,6 +210,7 @@ ttypescript patches typescript in order to use transformers in tsconfig.json. Se
     "plugins": [
         {
             "transform": "@automapper/classes/transformer-plugin",
+            "import": "tspBefore",
             "modelFileNameSuffix": [...]
         }
     ],

--- a/packages/classes/transformer-plugin/src/index.ts
+++ b/packages/classes/transformer-plugin/src/index.ts
@@ -52,5 +52,10 @@ export const before = (
     program: Program
 ) => automapperTransformerPlugin(program, options).before;
 
+export const tspBefore = (
+  program: Program,
+  options: AutomapperTransformerPluginOptions
+) => automapperTransformerPlugin(program, options).before;
+
 export * from './lib/options';
 export * from './lib/constants';


### PR DESCRIPTION
Hello.

I got a bug report on [ts-patch](https://github.com/nonara/ts-patch):

- https://github.com/nonara/ts-patch/issues/104

Upon investigating, I found that it had to do with an issue in the @automapper/classes/transformer-plugin transformer.

The issue seems to be that the instructions are incorrect for use with `ttypescript` / `ts-patch`, and there is currently no export which would work with them.

## Background

For some background, I wrote ts-patch, which was in parallel to `ttypescript` for a while. 

After some time, tts wasn't being maintained any more, but users would open PRs to propagate my logic in. More recently, ttypescript has effectively been deprecated, as it no longer supports TS v5+, and it seems there are no plans to.

I did significant rewrites to ts-patch, where it's diverged too much for it to be propagated in, and it also now has an in-memory compiler, so tts is no longer needed.

## Changes

I made three changes. 

First, the signature of your default export was in a format that wouldn't work for `ttypescript` or `ts-patch`. You can see the signatures here:

- https://github.com/cevek/ttypescript#pluginconfigtype

Essentially, we're looking for a transformer factory. Our default is the "program" type.

Your `before` export almost would have worked, but the order of program and options was reversed. As a result, I added the  `tspBefore` wrapper.

The second change was to update the doc to include the `import` key, as it is necessary, since we can't use the `default` export.

Lastly, I updated the instructions to point to `ts-patch` instead of tts, due to it being effectively deprecated. That said, if anyone uses this same config with tts, using typescript <5, it will work for that as well.

You're welcome to make any changes that you'd like! I just wanted the submission to be as complete as possible to save you some time. 

Take care!