### PR TITLE
fix: ignore import path transformations on win32 platform

### DIFF
--- a/packages/classes/transformer-plugin/src/lib/utils.ts
+++ b/packages/classes/transformer-plugin/src/lib/utils.ts
@@ -110,6 +110,11 @@ export function replaceImportPath(
     if (!importPath) {
         return undefined;
     }
+
+    if (process.platform === 'win32') {
+      return typeReference.replace('import', 'require')
+    }
+
     importPath = importPath.slice(2, importPath.length - 1);
 
     let relativePath = posix.relative(dirname(fileName), importPath);

--- a/packages/classes/transformer-plugin/src/lib/utils.ts
+++ b/packages/classes/transformer-plugin/src/lib/utils.ts
@@ -39,7 +39,7 @@ export function getDecoratorOrUndefinedByNames(
     names: string[],
     decorators?: readonly Decorator[]
 ): Decorator | undefined {
-    return (decorators || []).find((item) =>
+    return (decorators ? decorators : []).find((item) =>
         names.includes(getDecoratorName(item) as string)
     );
 }


### PR DESCRIPTION
The current version of the library throws me a bunch of errors, when trying to build my nest application with `transformer-plugin` enabled.

In general, the plugin works fine when DTOs are simple enough. But in cases, when classes have complex properties represented by other classes defined elsewhere. In such cases, the application doesn't start as the plugin breaks all such imports

Errors state, that:
```
ERROR in ../../libs/shared/src/models/dto/user.dto.ts 29:41-155
Module not found: Error: Can't resolve '../H:\projects\myproject\libs\shared\src\models\dto\client-user.dto' in 'H:\projects\myproject\libs\shared\src\models\dto'
****
```
Which means, it replaces the short relative path (originally `import { ClientDto } from './client.dto';`) with a long absolute path starting with `../`.

Don't know, why you use `path.posix.relative` and not just `path.relative`, but however, for the best compatibility possible, I made the if statement to skip all these path transformations when running on a windows environment.

Briefly tested on one of my projects, and this little change fixed me 75 errors, and none of the mappings broke.

P.S. The second commit was created only to pass the sonar verification. Didn't change it to the recommended '??' for backward compatibility, as I'm not ready to properly test the related functionality

P.S.S. @nartc appreciate if you check and merge it ASAP as I really like your package architecturally wise, but it's the only thing that blocks me from running some of my projects natively on my windows laptop.