### PR TITLE
fix(classes): fix main (i.e. ".") export of package.json

### DIFF
--- a/packages/classes/package.json
+++ b/packages/classes/package.json
@@ -7,7 +7,7 @@
         "reflect-metadata": "~0.1.13"
     },
     "exports": {
-        "./": {
+        ".": {
             "types": "./src/index.d.ts",
             "import": "./index.js",
             "require": "./index.cjs"


### PR DESCRIPTION
ISSUES CLOSED: #587

I've simply replaced "./" with "." in the main export of `@automapper/classes`'s `package.json`.