### PR TITLE
fix: remove / from  @automapper/classes default exports

### DIFF
--- a/packages/classes/package.json
+++ b/packages/classes/package.json
@@ -7,7 +7,7 @@
         "reflect-metadata": "~0.1.13"
     },
     "exports": {
-        "./": {
+        ".": {
             "types": "./src/index.d.ts",
             "import": "./index.js",
             "require": "./index.cjs"


### PR DESCRIPTION
This is needed since without this webpack was not able to build the project with this dependency. 

Tests  all green. 