### PR TITLE
fix(core): properties with similar names map to undefined

### DIFF
--- a/packages/core/src/lib/utils/get-path.ts
+++ b/packages/core/src/lib/utils/get-path.ts
@@ -36,7 +36,7 @@ export function getFlatteningPaths(
     );
     let trueFirstPartOfSource = first;
     let stopIndex = 0;
-    let found = hasProperty(src, trueFirstPartOfSource);
+    let found = hasProperty(src, trueFirstPartOfSource) && typeof src[trueFirstPartOfSource] === 'object';
 
     if (!found) {
         for (let i = 0, len = paths.length; i < len; i++) {
@@ -45,7 +45,7 @@ export function getFlatteningPaths(
                     trueFirstPartOfSource,
                     paths[i],
                 ]);
-            if (hasProperty(src, trueFirstPartOfSource)) {
+            if (hasProperty(src, trueFirstPartOfSource) && typeof src[trueFirstPartOfSource] === 'object') {
                 stopIndex = i + 1;
                 found = true;
                 break;


### PR DESCRIPTION
As described in https://github.com/nartc/mapper/issues/527, in cases where there are two properties with same "suffix" (starting with the same part) like `StartDate` and `StartDateTimeZone` it is assumed that `TimeZone` is actually nested property that needs to be flattened resulting in the property being undefined in the result.

Where the shared suffix is being searched in source object, however, and that is my solution to the problem, it's not checked whether it's actually object and thus needs to be flattened. In the reference source object, primitive values are all undefined, but when there's nested objects, they're expanded as objects with their own properties. So this fix verifies, that the property to be flattened is an object.

I'm honestly wasn't sure if I should add it only at the two places I did or to just add it to the `hasProperty` function. I also didn't find any existing spec for `getFlatteningPaths` and as I'm not familiar with it in depth and don't know all the requirements, I'm not sure I'm up to writing all the other test cases..