### PR TITLE
fix: Revert "fix: ignore import path transformations on win32 platform (#570)"

### DIFF
--- a/packages/classes/transformer-plugin/src/lib/utils.ts
+++ b/packages/classes/transformer-plugin/src/lib/utils.ts
@@ -39,7 +39,7 @@ export function getDecoratorOrUndefinedByNames(
     names: string[],
     decorators?: readonly Decorator[]
 ): Decorator | undefined {
-    return (decorators ? decorators : []).find((item) =>
+    return (decorators || []).find((item) =>
         names.includes(getDecoratorName(item) as string)
     );
 }
@@ -110,11 +110,6 @@ export function replaceImportPath(
     if (!importPath) {
         return undefined;
     }
-
-    if (process.platform === 'win32') {
-      return typeReference.replace('import', 'require')
-    }
-
     importPath = importPath.slice(2, importPath.length - 1);
 
     let relativePath = posix.relative(dirname(fileName), importPath);


### PR DESCRIPTION
This reverts commit 4089bb4d35548eb06a1defd6ee47ce23ca359a09.

I am not sure what the absolute paths were fixing but it causes issues building the application using NestJS on Windows machines.

I put together an example repo to reproduce this error:
https://github.com/v-beltran/automapper-class-import-bug

## v8.8.1
![Cmd1](https://github.com/nartc/mapper/assets/6894352/80100bbf-d088-4fec-9279-c6addc0481a4)
![require1](https://github.com/nartc/mapper/assets/6894352/2bc81d44-c8b4-43a1-ad51-696d553a3bb5)

## With "fix" reverted
![win32removed](https://github.com/nartc/mapper/assets/6894352/77fde2e2-b607-4a35-b3d6-905eec59cf44)
![require2](https://github.com/nartc/mapper/assets/6894352/f29d21e5-e930-4afb-8d65-17554074b1ce)
